### PR TITLE
Adding ability to accept challenges, pretty-print user data.

### DIFF
--- a/src/wochonecha/main.mo
+++ b/src/wochonecha/main.mo
@@ -1,20 +1,57 @@
 import Nat "mo:base/Nat";
+import Option "mo:base/Option";
 import Principal "mo:base/Principal";
 import User "./user";
+import Types "./types";
+import Array "mo:base/Array";
+
 import Challenge "./challenge";
 import AcceptedChallenge "./acceptedchallenge";
 import ChallengeDB "./challengedb";
 
 actor Wochonecha {
+  type ChallengeId = Types.ChallengeId;
+  type UserData = Types.UserData;
+
   var userDb : User.UserDb = User.UserDb();
   var challengeDB: ChallengeDB.ChallengeDB = ChallengeDB.ChallengeDB();
 
+
+  func userDataAsText(userData : UserData) : Text {
+    let userId : Text = Nat.toText(Nat.fromWord32(Principal.hash(userData.id)));
+    var userText : Text = "id: " # userId # ", name: " # userData.name # ", accepted: [";
+    for (challenge in userData.acceptedChallenges.vals()) {
+      userText := "" # userText # Nat.toText(challenge) # " ";
+    };
+    return userText # "]";
+  };
+
+
   public shared(msg) func createUser(username: Text) : async Text {
-    userDb.createUser(msg.caller, username);
-    "created user " # username # " with id " # Nat.toText(Nat.fromWord32(Principal.hash(msg.caller)))
+    let userData : UserData = userDb.createOrReturn(msg.caller, username);
+    "user: id = " # Nat.toText(Nat.fromWord32(Principal.hash(msg.caller))) # ", username = " # userData.name
+  };
+
+  public shared(msg) func acceptChallenge(challengeId : ChallengeId) : async Text {
+    let maybeUserData : ?UserData = userDb.findById(msg.caller);
+    if (Option.isNull(maybeUserData)) {
+      return "user not registered" 
+    };
+    let userData = Option.unwrap(maybeUserData);
+    let updatedUserData : UserData = {
+        id = userData.id;
+        name = userData.name;
+        acceptedChallenges = Array.append<ChallengeId>(userData.acceptedChallenges, [challengeId]);
+        completedChallenges = userData.completedChallenges;
+        friends = userData.friends;
+      };
+      userDb.update(updatedUserData);
+    "accepted challenge: " # userDataAsText(updatedUserData)
   };
 
   public query func getUser(username : Text) : async Text {
-     "querying for user " # username 
+    let users = userDb.findByName(username);
+    let userId  : Text = Nat.toText(Nat.fromWord32(Principal.hash(users[0].id)));
+     "querying for user " # username # ": " # userId
   };
 };

--- a/src/wochonecha/types.mo
+++ b/src/wochonecha/types.mo
@@ -2,7 +2,7 @@ import Principal "mo:base/Principal";
 
 module {
   public type UserId = Principal;
-  public type ChallengeId = Principal;
+  public type ChallengeId = Nat;
 
   public type Challenge = {
     id: ChallengeId;
@@ -18,15 +18,15 @@ module {
 
   public type ChallengeStats = {
     creator: UserId;
-    accepted: Nat;
-    completed: Nat;
+    acceptedCount: Nat;
+    completedCount: Nat;
   };
 
   public type UserData = {
     id: UserId;
     name: Text;
-    acceptedChallenges: [AcceptedChallenge];
-    completedChallenges: [AcceptedChallenge];
+    acceptedChallenges: [ChallengeId];
+    completedChallenges: [ChallengeId];
     friends: [UserId];
   };
 }

--- a/src/wochonecha/user.mo
+++ b/src/wochonecha/user.mo
@@ -1,26 +1,43 @@
 import Array "mo:base/Array";
 import HashMap "mo:base/HashMap";
+import Option "mo:base/Option";
 import Principal "mo:base/Principal";
 import Types "./types";
 
 module {
   type UserId = Types.UserId;
   type ChallengeId = Types.ChallengeId;
+
   type UserData = Types.UserData;
   type Challenge = Types.Challenge;
 
   public class UserDb() {
     func isEq(x: UserId, y: UserId): Bool { x == y };
 
-    let hashMap = HashMap.HashMap<UserId, UserData>(1, isEq, Principal.hash);
+    let db = HashMap.HashMap<UserId, UserData>(1, isEq, Principal.hash);
 
-    public func createUser(userId: UserId, username: Text) {
-      ignore hashMap.set(userId, makeUserData(userId, username));
+    public func createOrReturn(userId: UserId, username: Text) :  UserData {
+      let maybeUser = db.get(userId);
+      if (Option.isSome(maybeUser)) {
+        return Option.unwrap(maybeUser)
+      };
+      let userData = makeUserData(userId, username);
+      ignore db.set(userId, userData);
+      return userData;
+    };
+
+    public func update(userData: UserData) {
+      let userId: UserId = userData.id;
+      ignore db.set(userId, userData);
+    };
+
+    public func findById(userId: UserId): ?UserData {
+      db.get(userId)
     };
 
     public func findByName(username: Text): [UserData] {
       var users: [UserData] = [];
-      for ((id, userData) in hashMap.iter()) {
+      for ((id, userData) in db.iter()) {
         if (userData.name == username) {
           users := Array.append<UserData>(users, [userData]);
         };


### PR DESCRIPTION
Try it out with 

`~/ic-hackathon/wochonecha % dfx canister install --all --mode reinstall 
            
Installing code for canister wochonecha, with canister_id ic:03000000000000000000000000000000000179

Installing code for canister wochonecha_assets, with canister_id ic:040000000000000000000000000000000001AF

~/ic-hackathon/wochonecha % dfx canister call wochonecha createUser '("Alice")'     

("user: id = 993645956, username = Alice")

~/ic-hackathon/wochonecha % dfx canister call wochonecha createUser '("Bob")'  

("user: id = 993645956, username = Alice")

~/ic-hackathon/wochonecha % dfx canister call wochonecha acceptChallenge '(1)'      

("accepted challenge: id: 993645956, name: Alice, accepted: [1 ]")

~/ic-hackathon/wochonecha % dfx canister call wochonecha acceptChallenge '(1)'

("accepted challenge: id: 993645956, name: Alice, accepted: [1 1 ]")

~/ic-hackathon/wochonecha % dfx canister call wochonecha acceptChallenge '(2)'

("accepted challenge: id: 993645956, name: Alice, accepted: [1 1 2 ]")
`